### PR TITLE
Get MHSDIR from environment and fix gmcabal build

### DIFF
--- a/src/MicroCabal/Backend/MHS.hs
+++ b/src/MicroCabal/Backend/MHS.hs
@@ -20,8 +20,6 @@ mhsBackend = Backend {
   installPkgLib = mhsInstallLib
   }
 
-
-
 mhsNameVers :: Env -> IO (String, Version)
 mhsNameVers env = do
   v <- readVersion . takeWhile (/= '\n') <$> cmdOut env "mhs --numeric-version"

--- a/src/MicroCabal/Backend/MHS.hs
+++ b/src/MicroCabal/Backend/MHS.hs
@@ -1,9 +1,10 @@
 module MicroCabal.Backend.MHS(mhsBackend) where
 import Control.Monad
-import Data.Maybe (fromMaybe)
+import Data.List(dropWhileEnd)
+import Data.Maybe(fromMaybe)
 import Data.Version
 import System.Directory
-import System.Environment (lookupEnv)
+import System.Environment(lookupEnv)
 import MicroCabal.Cabal
 import MicroCabal.Env
 import MicroCabal.Parse(readVersion)
@@ -18,6 +19,8 @@ mhsBackend = Backend {
   installPkgExe = mhsInstallExe,
   installPkgLib = mhsInstallLib
   }
+
+
 
 mhsNameVers :: Env -> IO (String, Version)
 mhsNameVers env = do
@@ -78,8 +81,7 @@ mhs :: Env -> String -> IO ()
 mhs env args = do
   let flg = if verbose env == 1 then "-l " else if verbose env > 1 then "-v " else ""
   mhsDir <- fmap (fromMaybe "/usr/local/lib/mhs") (lookupEnv "MHSDIR")
-  cmd env $ "MHSDIR=" ++ mhsDir ++ " " ++    -- temporary hack
-            "mhs " ++ flg ++ args
+  cmd env $ "MHSDIR=" ++ mhsDir ++ " mhs " ++ flg ++ args
 
 findMainIs :: Env -> [FilePath] -> FilePath -> IO FilePath
 findMainIs _ [] fn = error $ "cannot find " ++ show fn

--- a/src/MicroCabal/Backend/MHS.hs
+++ b/src/MicroCabal/Backend/MHS.hs
@@ -1,7 +1,9 @@
 module MicroCabal.Backend.MHS(mhsBackend) where
 import Control.Monad
+import Data.Maybe (fromMaybe)
 import Data.Version
 import System.Directory
+import System.Environment (lookupEnv)
 import MicroCabal.Cabal
 import MicroCabal.Env
 import MicroCabal.Parse(readVersion)
@@ -73,9 +75,10 @@ mhsBuildExe env _ (Section _ name flds) = do
   mhs env args
 
 mhs :: Env -> String -> IO ()
-mhs env args =
-  let flg = if verbose env == 1 then "-l " else if verbose env > 1 then "-v " else "" in
-  cmd env $ "MHSDIR=/usr/local/lib/mhs " ++    -- temporary hack
+mhs env args = do
+  let flg = if verbose env == 1 then "-l " else if verbose env > 1 then "-v " else ""
+  mhsDir <- fmap (fromMaybe "/usr/local/lib/mhs") (lookupEnv "MHSDIR")
+  cmd env $ "MHSDIR=" ++ mhsDir ++ " " ++    -- temporary hack
             "mhs " ++ flg ++ args
 
 findMainIs :: Env -> [FilePath] -> FilePath -> IO FilePath


### PR DESCRIPTION
I was kicking the tires on MicroHs/Cabal and found two things I could easily fix:

1. Get MHSDIR from environment variables (if present) to support non-global installs
2. Add an import so GHC can compile mcabal again

Thanks!