### PR TITLE
Optional comma in data-files

### DIFF
--- a/src/MicroCabal/Parse.hs
+++ b/src/MicroCabal/Parse.hs
@@ -382,7 +382,7 @@ parsers =
   , "category"                       # pFreeText
   , "copyright"                      # pFreeText
   , "data-dir"                       # pVSpace
-  , "data-files"                     # pVComma
+  , "data-files"                     # pVOptComma
   , "description"                    # pFreeText
   , "extra-doc-files"                # pVComma
   , "extra-source-files"             # pVOptComma


### PR DESCRIPTION
Because [the epic-0.9.3.3 cabal
file](https://hackage.haskell.org/package/epic-0.9.3.3/epic.cabal) uses spaces,
and not commas, let's use the list reader with optional commas. That way, it is
compatible with whatever cabal file motivated the usage of commas in this
field, and also with the epic file. This also mirrors the existing treatment of
extra-source-files, which makes sense, because there is little reason these
fields should have differing syntax.

Fixes #4.

