### PR TITLE
Set containers to 0.8, which builds with MHS

### DIFF
--- a/src/MicroCabal/Main.hs
+++ b/src/MicroCabal/Main.hs
@@ -151,7 +151,7 @@ cmdUpdate _ _ = usage
 -- Should get these from global-hints (?)
 distPkgs :: [StackagePackage]
 distPkgs =
-  [ StackagePackage "containers"   (makeVersion [0,6,8])    False []
+  [ StackagePackage "containers"   (makeVersion [0,8])      False []
   , StackagePackage "deepseq"      (makeVersion [1,5,0,0])  False []
   , StackagePackage "mtl"          (makeVersion [2,3,1])    False []
   , StackagePackage "time"         (makeVersion [1,12,2])   False []


### PR DESCRIPTION
Currently attempting to install containers fails as

```
$ mcabal install containers
mcabal: Build package containers
mcabal: Building in /home/meooow/.mcabal/packages/containers-0.6.8
mcabal: Building library containers
mhs: error: dependency not installed: template-haskell
```