### PR TITLE
fix the pkgconfig-depends cabal field name

### DIFF
--- a/src/MicroCabal/Parse.hs
+++ b/src/MicroCabal/Parse.hs
@@ -413,7 +413,7 @@ parsers =
   , "other-extensions"               # pVOptComma
   , "other-languages"                # (VItem <$> pItem)
   , "other-modules"                  # pVOptComma
-  , "pkg-config-depends"             # pVComma
+  , "pkgconfig-depends"              # pVComma
   , "virtual-modules"                # pVComma
   --- library fields
   , "visibility"                     # (VItem <$> pItem)


### PR DESCRIPTION
see: https://cabal.readthedocs.io/en/stable/cabal-package-description-file.html#pkg-field-pkgconfig-depends

best,
andrea