### PR TITLE
Remove mtl-mhs override

### DIFF
--- a/src/MicroCabal/Backend/MHS.hs
+++ b/src/MicroCabal/Backend/MHS.hs
@@ -239,7 +239,6 @@ mhsPatchName nv = nv
 mhsPackages :: [(Name, (Name, Version))]
 mhsPackages =
   [ ("array",  ("array-mhs",  makeVersion [0,5,8,0]))
-  , ("mtl",    ("mtl-mhs",    makeVersion [2,3,1]))
   , ("random", ("random-mhs", makeVersion [1,3,2,1]))
   ]
 


### PR DESCRIPTION
mtl builds with mhs now (tested on 0.14.27.0), so the override only causes confusion.

In particular, the override causes problems in Nixpkgs because Nixpkgs doesn't know about the `mtl-mhs` dependency that the override introduces. For `array-mhs` and `random-mhs`, we have a workaround, but it doesn't make sense to use it for `mtl` when the real package works.

For example, trying to build `atrans` fails:

```
mcabal: Building library atrans
mcabal: Creating path module dist-mcabal/autogen/Paths_atrans.hs
mcabal: uncaught exception: error: "src/MicroCabal/Main.hs",361:7: dependency not installed: mtl-mhs
```