### PR TITLE
Add test command

### DIFF
--- a/src/MicroCabal/Backend/GHC.hs
+++ b/src/MicroCabal/Backend/GHC.hs
@@ -101,7 +101,7 @@ setupStdArgs env flds = do
 binGhc :: FilePath
 binGhc  = "bin" </> "ghc"
 
-ghcBuildExe :: Env -> Section -> Section -> IO ()
+ghcBuildExe :: Env -> Section -> Section -> IO FilePath
 ghcBuildExe env _ (Section _ name flds) = do
   initDB env
   let mainIs  = getFieldString flds "main-is"
@@ -114,6 +114,7 @@ ghcBuildExe env _ (Section _ name flds) = do
                 [ ">/dev/null" | verbose env <= 0 ]
   message env 0 $ "Building executable " ++ bin ++ " with ghc"
   ghc env args
+  return bin
 
 findMainIs :: Env -> [FilePath] -> FilePath -> IO FilePath
 findMainIs _ [] fn = error $ "cannot find " ++ show fn

--- a/src/MicroCabal/Backend/MHS.hs
+++ b/src/MicroCabal/Backend/MHS.hs
@@ -118,7 +118,7 @@ setupStdArgs env flds = do
 binMhs :: String
 binMhs  = "bin" </> "mhs"
 
-mhsBuildExe :: Env -> Section -> Section -> IO ()
+mhsBuildExe :: Env -> Section -> Section -> IO FilePath
 mhsBuildExe env (Section _ _ gflds) (Section _ name flds) = do
   initDB env
   let mainIs  = getFieldString  flds         "main-is"
@@ -135,6 +135,7 @@ mhsBuildExe env (Section _ _ gflds) (Section _ name flds) = do
                           ["-z", "-a.","-o" ++ bin, mainIs']
   message env 0 $ "Build " ++ bin ++ " with mhs"
   mhs env args
+  return bin
 
 mhs :: Env -> String -> IO ()
 mhs env args = do

--- a/src/MicroCabal/Env.hs
+++ b/src/MicroCabal/Env.hs
@@ -25,7 +25,7 @@ data Env = Env {
   subDir     :: Maybe String        -- subdirectory of git repo
   }
 
-data Target = TgtLib | TgtFor | TgtExe
+data Target = TgtLib | TgtFor | TgtExe | TgtTst
   deriving (Eq)
 
 data Backend = Backend {
@@ -36,7 +36,7 @@ data Backend = Backend {
   doesPkgExist   :: Env -> PackageName        -> IO Bool,   -- is the package available in the database?
   patchDepends   :: Env -> Cabal -> Cabal,                  -- patch dependencies
   patchName      :: Env -> (Name, Version) -> (Name, Version), -- patch package name
-  buildPkgExe    :: Env -> Section -> Section -> IO (),     -- build executable the current directory
+  buildPkgExe    :: Env -> Section -> Section -> IO FilePath,  -- build executable the current directory
   buildPkgLib    :: Env -> Section -> Section -> IO (),     -- build the package in the current directory
   buildPkgForLib :: Env -> Section -> Section -> IO (),     -- build the foreign-library in the current directory
   installPkgExe  :: Env -> Section -> Section -> IO (),     -- install the package from the current directory

--- a/src/MicroCabal/Main.hs
+++ b/src/MicroCabal/Main.hs
@@ -30,6 +30,7 @@ main = do
     [] -> usage
     ["--version"]  -> putStrLn version
     "build"   : as -> decodeGit cmdBuild   env as
+    "test"    : as ->           cmdTest    env as
     "clean"   : as ->           cmdClean   env as
     "fetch"   : as -> decodeGit cmdFetch   env as
     "help"    : as ->           cmdHelp    env as
@@ -257,6 +258,10 @@ cmdBuild env [apkg] = do
   cmdBuild env []
 cmdBuild _ _ = usage
 
+cmdTest :: Env -> [String] -> IO ()
+cmdTest env [] = build env { targets = TgtTst : targets env }
+cmdTest _ _ = usage
+
 getGlobal :: Cabal -> Section
 getGlobal (Cabal sects) =
   fromMaybe (error "no global section") $ listToMaybe [ s | s@(Section "global" _ _) <- sects ]
@@ -296,19 +301,22 @@ build env = do
       sectLib s@(Section "library"         _ _) | TgtLib `elem` targets env && isBuildable s = buildLib env glob s
       sectLib s@(Section "foreign-library" _ _) | TgtFor `elem` targets env && isBuildable s = buildForeignLib env glob s
       sectLib _ = return Nothing
-      sectExe ll s@(Section "executable"      _ _) | TgtExe `elem` targets env && isBuildable s = buildExe env glob s ll
+      sectExe ll s@(Section "executable"   _ _) | TgtExe `elem` targets env && isBuildable s = void $ buildExe env glob s ll
       sectExe _ _ = return ()
+      sectTst ll s@(Section "test-suite"   _ _) | TgtTst `elem` targets env && isBuildable s = buildExe env glob s ll >>= cmd env
+      sectTst _ _ = return ()
       sects' = addMissing sects
   message env 3 $ "Unnormalized Cabal file:\n" ++ show cbl
   message env 2 $ "Normalized Cabal file:\n" ++ show ncbl
   -- Build libs first, then exes
-  localLibs <- mapM sectLib sects'
-  mapM_ (sectExe $ catMaybes localLibs) sects'
+  localLibs <- catMaybes <$> mapM sectLib sects'
+  mapM_ (sectExe localLibs) sects'
+  mapM_ (sectTst localLibs) sects'
 
 isBuildable :: Section -> Bool
 isBuildable (Section _ _ flds) = getFieldBool True flds "buildable"
 
-buildExe :: Env -> Section -> Section -> [Name] -> IO ()
+buildExe :: Env -> Section -> Section -> [Name] -> IO FilePath
 buildExe env glob@(Section _ _ sglob) sect@(Section _ name flds) localLibs = do
   message env 0 $ "Building executable " ++ name
   createPathFile env glob sect
@@ -469,6 +477,7 @@ cmdHelp :: Env -> [String] -> IO ()
 cmdHelp _ _ = putStrLn "\
   \Available commands:\n\
   \  mcabal [FLAGS] build [--git=URL [--dir=DIR]] [PKG]    build in current directory, or the package PKG\n\
+  \  mcabal [FLAGS] test                                   build and run tests in current directory\n\
   \  mcabal [FLAGS] clean                                  clean in the current directory\n\
   \  mcabal [FLAGS] fetch [--git=URL [--dir=DIR]] PKG      fetch files for package PKG\n\
   \  mcabal [FLAGS] help                                   show this message\n\


### PR DESCRIPTION
Running Hspec tests on CI currently still requires manual steps:

1. The `.cabal` file has to be modified, changing `test-suite` to `executable` so that `mcabal` builds it.
2. `hspec-discover` has to be invoked manually because `mhs` does not interpret GHC options `-F -Fpgm`.
3. The test suite has to be invoked manually.



This PR addresses (1) and (3) by adding a `test` command.

### showcase
https://github.com/hspec/hspec-example/pull/38

![IMG_2036](https://github.com/user-attachments/assets/cee5b446-5249-4237-8d56-e687dfe2f8ce)

